### PR TITLE
Fix in firefox / safari

### DIFF
--- a/src/helpers/headersFromResponse.js
+++ b/src/helpers/headersFromResponse.js
@@ -2,7 +2,7 @@ function getHeadersFromEntries (responseHeaders) {
   const headerKeys = responseHeaders.keys();
   const headers = {};
   Array.from(headerKeys).forEach((key) => {
-    const value = responseHeaders.getAll ? responseHeaders.getAll(key) : responseHeaders.get(key);
+    const value = typeof(responseHeaders.getAll) === 'function' ? responseHeaders.getAll(key) : responseHeaders.get(key);
     if (value.count > 1) {
       headers[key] = value;
     } else {

--- a/src/helpers/headersFromResponse.js
+++ b/src/helpers/headersFromResponse.js
@@ -2,7 +2,7 @@ function getHeadersFromEntries (responseHeaders) {
   const headerKeys = responseHeaders.keys();
   const headers = {};
   Array.from(headerKeys).forEach((key) => {
-    const value = typeof(responseHeaders.getAll) === 'function' ? responseHeaders.getAll(key) : responseHeaders.get(key);
+    const value = typeof responseHeaders.getAll === 'function' ? responseHeaders.getAll(key) : responseHeaders.get(key);
     if (value.count > 1) {
       headers[key] = value;
     } else {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2700294/26460240/4a746972-4136-11e7-819f-2b28dd290bc7.png)

We're getting this error because getAll exists but not as a function. https://developer.mozilla.org/en-US/docs/Web/API/Headers/getAll it looks like Headers.get() returns all header keys now so we might be able to get away with using just that.

![image](https://cloud.githubusercontent.com/assets/2700294/26460556/3d4ffd0a-4137-11e7-8d98-04ea106af053.png)

Working ^^^^